### PR TITLE
Fix issue with wrong smoothness for the non-fractional rational approximation.

### DIFF
--- a/R/fractional.operators.R
+++ b/R/fractional.operators.R
@@ -123,7 +123,7 @@ fractional.operators <- function(L,
     Pr <- I
     Pl <- L
     if (beta > 1) {
-      for (i in 1:beta) {
+      for (i in 1:(beta - 1)) {
         Pl <- Pl %*% CiL
       }
     }


### PR DESCRIPTION
The for-loop runs one time too much when iteratively building the non-fractional Pl-matrix.

As an example, for a smoothness $\beta = 2$ the loop gives $\text{Pl} = \mathbf{L}\left(\mathbf{C}^{-1}\mathbf{L}\right)\left(\mathbf{C}^{-1}\mathbf{L}\right)$. However, to obtain a correct expression for $\mathbf{Q}$ this needs to be $\text{Pl} = \mathbf{L}\left(\mathbf{C}^{-1}\mathbf{L}\right)$.