### PR TITLE
Fix invalid and deprecated INLA mesh code to use proper fmesher code

### DIFF
--- a/tests/testthat/test.fem.R
+++ b/tests/testthat/test.fem.R
@@ -6,19 +6,19 @@ test_that("FEM matrix construction", {
   if(!inla_installed){
     testthat::skip("INLA not installed")
   }
-  
+
   old_threads <- INLA::inla.getOption("num.threads")
   INLA::inla.setOption(num.threads = "1:1")
 
   x <- c(0,1,1.75,2)
   fem <- rSPDE.fem1d(x)
-  mesh <- INLA::inla.mesh.1d(x)
-  fem_inla <- INLA::inla.mesh.fem(mesh)
-  
+  mesh <- fmesher::fm_mesh_1d(x)
+  fem_inla <- fmesher::fm_fem(mesh)
+
   # Pr multiplication
   expect_equal(fem$C, fem_inla$c1, tolerance = 1e-10)
   expect_equal(fem$G, fem_inla$g1, tolerance = 1e-10)
-  
+
     INLA::inla.setOption(num.threads = old_threads)
 })
 
@@ -28,7 +28,7 @@ test_that("A matrix construction", {
   if(!inla_installed){
     testthat::skip("INLA not installed")
   }
-  
+
   old_threads <- INLA::inla.getOption("num.threads")
   INLA::inla.setOption(num.threads = "1:1")
 
@@ -36,9 +36,9 @@ test_that("A matrix construction", {
   fem <- rSPDE.fem1d(x)
   loc <- c(0.6,1.1,2)
   A <- rSPDE.A1d(x,loc)
-  mesh <- INLA::inla.mesh.1d(x)
-  A_inla <- INLA::inla.mesh.1d.A(mesh,loc)
-  
+  mesh <- fmesher::fm_mesh_1d(x)
+  A_inla <- fmesher::fm_basis(mesh,loc)
+
   # Pr multiplication
   expect_equal(A, A_inla, tolerance = 1e-10)
 


### PR DESCRIPTION
A single use of `fm_bary()` assumed the old output format from `INLA::inla.fmesher.smorg()` which has been deprecated for over a year and was recently removed from INLA. In addition, the devel version of fmesher has just changed the output format of fm_bary() to be a more proper object, with slightly different storage. The new code checks the fmesher version, so should be compatible with both old and new fmesher versions. The affected function, `rspde.mesh.project.inla.mesh`, doesn't seem to be used anywhere, so impact of the bug should have been minimal.
