### PR TITLE
fmesher mesh class handling improvement

### DIFF
--- a/R/inla_rspde.R
+++ b/R/inla_rspde.R
@@ -2679,7 +2679,7 @@ rspde.mesh.project.rspde.mesh.projector <- function(projector, field, ...) {
 
 rspde.mesh.project.inla.mesh.1d <- function(mesh, loc, field = NULL,
                                             rspde.order = 1, nu = NULL, ...) {
-  stopifnot(inherits(mesh, "inla.mesh.1d"))
+  stopifnot(inherits(mesh, "fm_mesh_1d"))
   if (!missing(field) && !is.null(field)) {
     proj <- rspde.mesh.projector(mesh, loc,
       rspde.order = rspde.order, nu = nu, ...

--- a/R/inla_rspde.R
+++ b/R/inla_rspde.R
@@ -176,7 +176,7 @@ rspde.matern <- function(mesh,
     }
   }
 
-  if (inherits(mesh, c("inla.mesh", "inla.mesh.1d"))) {
+  if (inherits(mesh, c("fm_mesh_1d", "fm_mesh_2d"))) {
     d <- get_inla_mesh_dimension(mesh)
   } else if (!is.null(mesh$d)) {
     d <- mesh$d
@@ -355,7 +355,7 @@ rspde.matern <- function(mesh,
 
   ### STATIONARY PART
   if (stationary) {
-    if (inherits(mesh, c("inla.mesh", "inla.mesh.1d"))) {
+    if (inherits(mesh, c("fm_mesh_1d", "fm_mesh_2d"))) {
       if (integer_alpha) {
         integer.nu <- TRUE
         if (d == 1) {
@@ -682,7 +682,7 @@ rspde.matern <- function(mesh,
   } else {
     ### NONSTATIONARY PART
 
-    if (inherits(mesh, c("inla.mesh", "inla.mesh.1d"))) {
+    if (inherits(mesh, c("fm_mesh_1d", "fm_mesh_2d"))) {
       if (integer_alpha) {
         integer.nu <- TRUE
         if (d == 1) {
@@ -947,8 +947,8 @@ spde.make.A <- function(mesh = NULL,
                         n.group = NULL,
                         n.repl = NULL) {
   if (!is.null(mesh)) {
-    cond1 <- inherits(mesh, "inla.mesh.1d")
-    cond2 <- inherits(mesh, "inla.mesh")
+    cond1 <- inherits(mesh, "fm_mesh_1d")
+    cond2 <- inherits(mesh, "fm_mesh_2d")
     cond3 <- inherits(mesh, "metric_graph")
     stopifnot(cond1 || cond2 || cond3)
     if (cond1 || cond2) {
@@ -1127,8 +1127,8 @@ rspde.make.A <- function(mesh = NULL,
                          n.group = NULL,
                          n.repl = NULL) {
   if (!is.null(mesh)) {
-    cond1 <- inherits(mesh, "inla.mesh.1d")
-    cond2 <- inherits(mesh, "inla.mesh")
+    cond1 <- inherits(mesh, "fm_mesh_1d")
+    cond2 <- inherits(mesh, "fm_mesh_2d")
     cond3 <- inherits(mesh, "metric_graph")
     stopifnot(cond1 || cond2 || cond3)
     if (cond1 || cond2) {
@@ -1338,12 +1338,12 @@ rspde.make.index <- function(name, n.spde = NULL, n.group = 1,
   }
 
   if (!is.null(mesh)) {
-    cond1 <- inherits(mesh, "inla.mesh.1d")
-    cond2 <- inherits(mesh, "inla.mesh")
+    cond1 <- inherits(mesh, "fm_mesh_1d")
+    cond2 <- inherits(mesh, "fm_mesh_2d")
     cond3 <- inherits(mesh, "metric_graph")
     stopifnot(cond1 || cond2 || cond3)
     if (cond1 || cond2) {
-      n_mesh <- mesh$n
+      n_mesh <- fmesher::fm_dof(mesh)
       dim <- get_inla_mesh_dimension(mesh)
     } else if (cond3) {
       dim <- 1
@@ -2598,8 +2598,8 @@ rspde.mesh.projector <- function(mesh,
 rspde.mesh.project.inla.mesh <- function(mesh, loc = NULL,
                                          field = NULL, rspde.order = 1,
                                          nu = NULL, ...) {
-  cond1 <- inherits(mesh, "inla.mesh.1d")
-  cond2 <- inherits(mesh, "inla.mesh")
+  cond1 <- inherits(mesh, "fm_mesh_1d")
+  cond2 <- inherits(mesh, "fm_mesh_2d")
   stopifnot(cond1 || cond2)
 
   if (!missing(field) && !is.null(field)) {

--- a/R/inla_rspde_intrinsic.R
+++ b/R/inla_rspde_intrinsic.R
@@ -1,22 +1,22 @@
 #' @name rspde.matern.intrinsic
 #' @title Intrinsic Matern rSPDE model object for INLA
 #' @description Creates an INLA object for a stationary intrinsic Matern model.
-#' Currently, alpha is fixed to 2 and beta is fixed to 1. 
+#' Currently, alpha is fixed to 2 and beta is fixed to 1.
 #' @param mesh The mesh to build the model. It can be an `inla.mesh` or
 #' an `inla.mesh.1d` object. Otherwise, should be a list containing elements d, the dimension, C, the mass matrix,
 #' and G, the stiffness matrix.
-#' @param alpha Smoothness parameter, need to be 1 or 2. 
+#' @param alpha Smoothness parameter, need to be 1 or 2.
 #' @param mean.correction Add mean correction for extreme value models?
 #' @param start.lkappa Starting value for log of kappa.
 #' @param prior.lkappa.mean Prior on log kappa to be used for the priors and for the starting values.
 #' @param prior.ltau.mean Prior on log tau to be used for the priors and for the starting values.
 #' @param prior.lkappa.prec Precision to be used on the prior on log kappa to be used for the priors and for the starting values.
 #' @param prior.ltau.prec Precision to be used on the prior on log tau to be used for the priors and for the starting values.
-#' @param start.ltau Starting value for log of tau. 
-#' @param true.scaling Compute the true normalizing constant manually? Default `TRUE`. 
+#' @param start.ltau Starting value for log of tau.
+#' @param true.scaling Compute the true normalizing constant manually? Default `TRUE`.
 #' The alternative is to set this to `FALSE` and set the `diagonal` argument to some small
-#' positive value. In the latter case, the model is approximated by a non-intrinsic model 
-#' with a precision matrix that has the `diagonal` value added to the diagonal. 
+#' positive value. In the latter case, the model is approximated by a non-intrinsic model
+#' with a precision matrix that has the `diagonal` value added to the diagonal.
 #' @param diagonal Value of diagonal correction for INLA stability. Default 0.
 #' @param debug INLA debug argument
 #' @param shared_lib Which shared lib to use for the cgeneric implementation?
@@ -59,37 +59,37 @@ rspde.intrinsic.matern <- function(mesh,
     if (!(alpha %in% c(1,2))){
         stop("Only alpha = 1 or alpha = 2 implemented.")
     }
-    
+
     if (prior.lkappa.prec < 0 || prior.ltau.prec < 0) {
         stop("Need positive precisions for the priors.")
     }
     ### Location of object files
-    
+
     rspde_lib <- get_shared_library(shared_lib)
-    
-    if (inherits(mesh, c("inla.mesh", "inla.mesh.1d"))) {
+
+    if (inherits(mesh, c("fm_mesh_1d", "fm_mesh_2d"))) {
         d <- get_inla_mesh_dimension(mesh)
     } else if (!is.null(mesh$d)) {
         d <- mesh$d
     } else {
         stop("The mesh object should either be an INLA mesh object or contain d, the dimension!")
     }
-    
+
     ### Priors and starting values
     if(is.null(prior.lkappa.mean)){
-        mesh.range <- ifelse(d == 2, (max(c(diff(range(mesh$loc[,1])), 
-                                            diff(range(mesh$loc[, 2])), 
-                                            diff(range(mesh$loc[,3]))))), 
+        mesh.range <- ifelse(d == 2, (max(c(diff(range(mesh$loc[,1])),
+                                            diff(range(mesh$loc[, 2])),
+                                            diff(range(mesh$loc[,3]))))),
                              diff(mesh$interval))
         prior.lkappa.mean <- log(sqrt(8)/(0.2*mesh.range))
     }
-    
+
     theta.prior.mean <- c(prior.ltau.mean, prior.lkappa.mean)
-    
+
     theta.prior.prec <- diag(c(prior.ltau.prec, prior.lkappa.prec))
     start.theta <- theta.prior.mean
 
-    
+
     if (!is.null(start.lkappa)) {
         start.theta[2] <- start.lkappa
     }
@@ -97,36 +97,36 @@ rspde.intrinsic.matern <- function(mesh,
         start.theta[1] <- start.ltau
     }
 
-    
+
     ### FEM matrices
-    if (inherits(mesh, c("inla.mesh", "inla.mesh.1d"))) {
-        
+    if (inherits(mesh, c("fm_mesh_1d", "fm_mesh_2d"))) {
+
         if (d == 1) {
             fem_mesh <- fem_mesh_order_1d(mesh, m_order = alpha + 1)
         } else {
             fem_mesh <- fm_fem(mesh, order = alpha + 1)
         }
-        
+
     } else {
         if (is.null(mesh$C) || is.null(mesh$G)) {
-            stop("If mesh is not an inla.mesh object, you should manually supply a list with elements c0, g1, g2...")
+            stop("If mesh is not an fm_mesh_1d/2d object, you should manually supply a list with elements c0, g1, g2...")
         }
         fem_mesh <- generic_fem_mesh_order(mesh, m_order = alpha + 1)
     }
-    
+
     n_cgeneric <- ncol(fem_mesh[["c0"]])
-    
+
     fem_mesh_orig <- fem_mesh
-    
+
     if(eigen.version) {
         C <- fem_mesh[["c0"]]
         G <- fem_mesh[["g1"]]
         fem_mesh <- fem_mesh[setdiff(names(fem_mesh), c("ta", "va"))]
-        
+
         fem_mesh <- lapply(fem_mesh, transpose_cgeneric)
-        
+
         if(alpha==1) {
-            graph_opt <- fem_mesh[["g2"]]    
+            graph_opt <- fem_mesh[["g2"]]
         } else {
             graph_opt <- fem_mesh[["g3"]]
         }
@@ -136,7 +136,7 @@ rspde.intrinsic.matern <- function(mesh,
                 list(
                     model = "inla_cgeneric_rspde_intrinsic_eigen_cache",
                     shlib = rspde_lib,
-                    n = as.integer(n_cgeneric), 
+                    n = as.integer(n_cgeneric),
                     debug = debug,
                     graph_opt_i = graph_opt@i,
                     graph_opt_j = graph_opt@j,
@@ -156,7 +156,7 @@ rspde.intrinsic.matern <- function(mesh,
                 list(
                     model = "inla_cgeneric_rspde_intrinsic_eigen",
                     shlib = rspde_lib,
-                    n = as.integer(n_cgeneric), 
+                    n = as.integer(n_cgeneric),
                     debug = debug,
                     graph_opt_i = graph_opt@i,
                     graph_opt_j = graph_opt@j,
@@ -169,71 +169,71 @@ rspde.intrinsic.matern <- function(mesh,
                     mean_correction = as.integer(mean.correction),
                     true_scaling = as.integer(true.scaling)
                 )
-            )    
+            )
         }
-        
+
     } else {
         fem_mesh <- fem_mesh[setdiff(names(fem_mesh), c("ta", "va"))]
-        
+
         fem_mesh <- lapply(fem_mesh, transpose_cgeneric)
-        
+
         C_list <- symmetric_part_matrix(fem_mesh$c0)
         G_1_list <- symmetric_part_matrix(fem_mesh$g1)
         G_2_list <- symmetric_part_matrix(fem_mesh$g2)
-        
-        
+
+
         idx_matrices <- list()
-        
+
         if(alpha == 2) {
             G_3_list <- symmetric_part_matrix(fem_mesh$g3)
-            
+
             idx_matrices[[1]] <- G_1_list$idx
             idx_matrices[[2]] <- G_2_list$idx
             idx_matrices[[3]] <- G_3_list$idx
-            
+
             positions_matrices_less <- list()
             positions_matrices_less[[1]] <- match(G_1_list$M, G_3_list$M)
             positions_matrices_less[[2]] <- match(G_2_list$M, G_3_list$M)
-            
+
             n_tmp <- length(fem_mesh[["g3"]]@x[idx_matrices[[3]]])
             tmp <- rep(0, n_tmp)
-            
+
             tmp[positions_matrices_less[[1]]] <- fem_mesh$g1@x[idx_matrices[[1]]]
             matrices_less <- tmp
-            
+
             tmp <- rep(0, n_tmp)
             tmp[positions_matrices_less[[2]]] <- fem_mesh$g2@x[idx_matrices[[2]]]
             matrices_less <- c(matrices_less, tmp)
-            
+
             tmp <- fem_mesh[["g3"]]@x[idx_matrices[[3]]]
             matrices_less <- c(matrices_less, tmp)
-            
+
             graph_opt <- fem_mesh[["g3"]]
         } else if (alpha == 1) {
             idx_matrices[[1]] <- G_1_list$idx
             idx_matrices[[2]] <- G_2_list$idx
-            
+
             positions_matrices_less <- list()
             positions_matrices_less[[1]] <- match(G_1_list$M, G_2_list$M)
-            
+
             n_tmp <- length(fem_mesh[["g2"]]@x[idx_matrices[[2]]])
             tmp <- rep(0, n_tmp)
-            
+
             tmp[positions_matrices_less[[1]]] <- fem_mesh$g1@x[idx_matrices[[1]]]
             matrices_less <- tmp
-            
+
             tmp <- fem_mesh[["g2"]]@x[idx_matrices[[2]]]
             matrices_less <- c(matrices_less, tmp)
-            
+
             graph_opt <- fem_mesh[["g2"]]
         }
-        
+
         model <- do.call(
             eval(parse(text = "INLA::inla.cgeneric.define")),
             list(
                 model = "inla_cgeneric_rspde_intrinsic_int_model",
                 shlib = rspde_lib,
-                n = as.integer(n_cgeneric), 
+                n = as.integer(n_cgeneric),
                 debug = debug,
                 matrices_less = as.double(matrices_less),
                 graph_opt_i = graph_opt@i,
@@ -244,15 +244,15 @@ rspde.intrinsic.matern <- function(mesh,
                 d = as.integer(d),
                 alpha = as.integer(alpha)
             )
-        )    
+        )
     }
-    
+
     model$cgeneric_type <- "intrinsic_matern"
     model$f$diagonal <- diagonal
     model$theta.prior.mean <- theta.prior.mean
     model$theta.prior.prec <- theta.prior.prec
     model$start.theta <- start.theta
-    
+
     class(model) <- c("inla_rspde", "intrinsic", class(model))
     model$parameterization <- "spde"
     model$stationary <- TRUE

--- a/man/matern2d.operators.Rd
+++ b/man/matern2d.operators.Rd
@@ -51,7 +51,7 @@ based on a SPDE representation of the form
 where $c>0$ is a constant. The matrix \eqn{H} is defined as
 \deqn{\begin{bmatrix}
 h_x^2 & h_xh_yh_{xy} \\
-h_xh_yh_{xy} & h_y^2 
+h_xh_yh_{xy} & h_y^2
 \end{bmatrix}}
 }
 \examples{

--- a/man/rspde.spacetime.Rd
+++ b/man/rspde.spacetime.Rd
@@ -98,9 +98,9 @@ graph$compute_fem()
 time_loc <- seq(from = 0, to = 10, length.out = 11)
 
 # Create the model
-model <- rspde.spacetime(mesh_space = graph, 
-                         time_loc = time_loc, 
-                         alpha = 2, 
+model <- rspde.spacetime(mesh_space = graph,
+                         time_loc = time_loc,
+                         alpha = 2,
                          beta = 1)
 
 }


### PR DESCRIPTION
Update fm_mesh_1d and fm_mesh_2d checks, and prepare for the future removal of the "inla.mesh" and "inla.mesh.1d" class names.

Unfortunately, the rstudio editor settings seem different; that explains most of the end-of-line-whitespace-only differences.