### PR TITLE
Set INLA/fmesher transition warnings in package tests

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,4 @@
+if (requireNamespace("INLA", quietly = TRUE)) {
+  INLA::inla.setOption(fmesher.evolution.warn = TRUE)
+  INLA::inla.setOption(fmesher.evolution.verbosity = "stop")
+}

--- a/tests/testthat/test.inla_rspde.R
+++ b/tests/testthat/test.inla_rspde.R
@@ -5,7 +5,7 @@ test_that("testing cgeneric_integer", {
   testthat::skip_on_cran()
 if (!requireNamespace("INLA", quietly=TRUE))
     testthat::skip(message = 'INLA package is not installed. (see www.r-inla.org/download-install)')
-  
+
   old_threads <- INLA::inla.getOption("num.threads")
   INLA::inla.setOption(num.threads = "1:1")
 
@@ -18,11 +18,11 @@ ind <- !is.na(Y)
 Y <- Y[ind]
 coords <- as.matrix(PRprec[ind, 1:2])
 
-prdomain <- INLA::inla.nonconvex.hull(coords, -0.03, -0.05, resolution = c(50, 50))
-prmesh <- INLA::inla.mesh.2d(boundary = prdomain, max.edge = c(0.45, 1), cutoff = 0.5)
+prdomain <- fmesher::fm_nonconvex_hull_inla(coords, -0.03, -0.05, resolution = c(50, 50))
+prmesh <- fmesher::fm_mesh_2d_inla(boundary = prdomain, max.edge = c(0.45, 1), cutoff = 0.5)
 
 
-rspde_model <- rspde.matern(mesh = prmesh, parameterization = "spde", 
+rspde_model <- rspde.matern(mesh = prmesh, parameterization = "spde",
 nu = 1)
 
 Q_tmp <- INLA::inla.cgeneric.q(rspde_model)
@@ -43,7 +43,7 @@ testthat::expect_equal(sum( (Q_1 - Q_tmp$Q)^2), 0)
 
 ## Testing matern parameterization
 
-rspde_model <- rspde.matern(mesh = prmesh, parameterization = "matern", 
+rspde_model <- rspde.matern(mesh = prmesh, parameterization = "matern",
 nu = 1)
 
 Q_tmp <- INLA::inla.cgeneric.q(rspde_model)
@@ -61,7 +61,7 @@ testthat::expect_equal(sum( (Q_tmp2 - Q_tmp$Q)^2), 0)
 #   testthat::skip_on_cran()
 # if (!requireNamespace("INLA", quietly=TRUE))
 #     testthat::skip(message = 'INLA package is not installed. (see www.r-inla.org/download-install)')
-  
+
 #   old_threads <- INLA::inla.getOption("num.threads")
 #   INLA::inla.setOption(num.threads = "1:1")
 
@@ -75,11 +75,11 @@ testthat::expect_equal(sum( (Q_tmp2 - Q_tmp$Q)^2), 0)
 # Y <- Y[ind]
 # coords <- as.matrix(PRprec[ind, 1:2])
 
-# prdomain <- INLA::inla.nonconvex.hull(coords, -0.03, -0.05, resolution = c(50, 50))
-# prmesh <- INLA::inla.mesh.2d(boundary = prdomain, max.edge = c(0.45, 1), cutoff = 0.5)
+# prdomain <- fmesher::fm_nonconvex_hull_inla(coords, -0.03, -0.05, resolution = c(50, 50))
+# prmesh <- fmesher::fm_mesh_2d(boundary = prdomain, max.edge = c(0.45, 1), cutoff = 0.5)
 
 
-# rspde_model <- rspde.matern(mesh = prmesh, parameterization = "spde", 
+# rspde_model <- rspde.matern(mesh = prmesh, parameterization = "spde",
 # nu = 0.4,
 # rspde.order = 0)
 
@@ -101,7 +101,7 @@ testthat::expect_equal(sum( (Q_tmp2 - Q_tmp$Q)^2), 0)
 
 # ## Testing matern parameterization
 
-# rspde_model <- rspde.matern(mesh = prmesh, parameterization = "matern", 
+# rspde_model <- rspde.matern(mesh = prmesh, parameterization = "matern",
 # nu = 0.4,
 # rspde.order = 0)
 
@@ -120,7 +120,7 @@ testthat::expect_equal(sum( (Q_tmp2 - Q_tmp$Q)^2), 0)
 #   testthat::skip_on_cran()
 # if (!requireNamespace("INLA", quietly=TRUE))
 #     testthat::skip(message = 'INLA package is not installed. (see www.r-inla.org/download-install)')
-  
+
 #   old_threads <- INLA::inla.getOption("num.threads")
 #   INLA::inla.setOption(num.threads = "1:1")
 
@@ -133,11 +133,11 @@ testthat::expect_equal(sum( (Q_tmp2 - Q_tmp$Q)^2), 0)
 # Y <- Y[ind]
 # coords <- as.matrix(PRprec[ind, 1:2])
 
-# prdomain <- INLA::inla.nonconvex.hull(coords, -0.03, -0.05, resolution = c(50, 50))
-# prmesh <- INLA::inla.mesh.2d(boundary = prdomain, max.edge = c(0.45, 1), cutoff = 0.5)
+# prdomain <- fmesher::fm_nonconvex_hull_inla(coords, -0.03, -0.05, resolution = c(50, 50))
+# prmesh <- fmesher::fm_mesh_2d(boundary = prdomain, max.edge = c(0.45, 1), cutoff = 0.5)
 
 
-# rspde_model <- rspde.matern(mesh = prmesh, parameterization = "spde", 
+# rspde_model <- rspde.matern(mesh = prmesh, parameterization = "spde",
 # start.nu = 0.4,
 # rspde.order = 0)
 
@@ -159,7 +159,7 @@ testthat::expect_equal(sum( (Q_tmp2 - Q_tmp$Q)^2), 0)
 
 # ## Testing matern parameterization
 
-# rspde_model <- rspde.matern(mesh = prmesh, parameterization = "matern", 
+# rspde_model <- rspde.matern(mesh = prmesh, parameterization = "matern",
 # start.nu = 0.4,
 # rspde.order = 0)
 
@@ -178,7 +178,7 @@ test_that("testing cgeneric_rspde_fixed_gen", {
   testthat::skip_on_cran()
 if (!requireNamespace("INLA", quietly=TRUE))
     testthat::skip(message = 'INLA package is not installed. (see www.r-inla.org/download-install)')
-  
+
   old_threads <- INLA::inla.getOption("num.threads")
   INLA::inla.setOption(num.threads = "1:1")
 
@@ -191,11 +191,11 @@ ind <- !is.na(Y)
 Y <- Y[ind]
 coords <- as.matrix(PRprec[ind, 1:2])
 
-prdomain <- INLA::inla.nonconvex.hull(coords, -0.03, -0.05, resolution = c(50, 50))
-prmesh <- INLA::inla.mesh.2d(boundary = prdomain, max.edge = c(0.45, 1), cutoff = 0.5)
+prdomain <- fmesher::fm_nonconvex_hull_inla(coords, -0.03, -0.05, resolution = c(50, 50))
+prmesh <- fmesher::fm_mesh_2d(boundary = prdomain, max.edge = c(0.45, 1), cutoff = 0.5)
 
 
-rspde_model <- rspde.matern(mesh = prmesh, parameterization = "spde", 
+rspde_model <- rspde.matern(mesh = prmesh, parameterization = "spde",
 start.nu = 0.4,
 rspde.order = 2)
 
@@ -205,7 +205,7 @@ Q_tmp2 <- precision(rspde_model)
 
 testthat::expect_equal(sum((Q_tmp$Q - Q_tmp2)^2), 0)
 
-rspde_model_fixed <- rspde.matern(mesh = prmesh, parameterization = "spde", 
+rspde_model_fixed <- rspde.matern(mesh = prmesh, parameterization = "spde",
 nu = 0.4,
 rspde.order = 2)
 
@@ -215,7 +215,7 @@ testthat::expect_equal(sum( (Q_tmp2$Q - Q_tmp$Q)^2), 0)
 
 ## Testing matern parameterization
 
-rspde_model <- rspde.matern(mesh = prmesh, parameterization = "matern", 
+rspde_model <- rspde.matern(mesh = prmesh, parameterization = "matern",
 start.nu = 0.4,
 rspde.order = 2)
 
@@ -233,7 +233,7 @@ test_that("testing cgeneric_rspde_gen", {
   testthat::skip_on_cran()
 if (!requireNamespace("INLA", quietly=TRUE))
     testthat::skip(message = 'INLA package is not installed. (see www.r-inla.org/download-install)')
-  
+
   old_threads <- INLA::inla.getOption("num.threads")
   INLA::inla.setOption(num.threads = "1:1")
 
@@ -246,11 +246,11 @@ ind <- !is.na(Y)
 Y <- Y[ind]
 coords <- as.matrix(PRprec[ind, 1:2])
 
-prdomain <- INLA::inla.nonconvex.hull(coords, -0.03, -0.05, resolution = c(50, 50))
-prmesh <- INLA::inla.mesh.2d(boundary = prdomain, max.edge = c(0.45, 1), cutoff = 0.5)
+prdomain <- fmesher::fm_nonconvex_hull_inla(coords, -0.03, -0.05, resolution = c(50, 50))
+prmesh <- fmesher::fm_mesh_2d(boundary = prdomain, max.edge = c(0.45, 1), cutoff = 0.5)
 
 
-rspde_model <- rspde.matern(mesh = prmesh, parameterization = "spde", 
+rspde_model <- rspde.matern(mesh = prmesh, parameterization = "spde",
 start.nu = 0.4,
 rspde.order = 2)
 
@@ -262,7 +262,7 @@ testthat::expect_equal(sum( (Q_1 - Q_tmp$Q)^2), 0)
 
 ## Testing matern parameterization
 
-rspde_model <- rspde.matern(mesh = prmesh, parameterization = "matern", 
+rspde_model <- rspde.matern(mesh = prmesh, parameterization = "matern",
 start.nu = 0.4,
 rspde.order = 2)
 
@@ -281,7 +281,7 @@ test_that("testing cgeneric_nonstat_gen", {
   testthat::skip_on_cran()
 if (!requireNamespace("INLA", quietly=TRUE))
     testthat::skip(message = 'INLA package is not installed. (see www.r-inla.org/download-install)')
-  
+
   old_threads <- INLA::inla.getOption("num.threads")
   INLA::inla.setOption(num.threads = "1:1")
 
@@ -293,8 +293,8 @@ ind <- !is.na(Y)
 Y <- Y[ind]
 coords <- as.matrix(PRprec[ind, 1:2])
 
-prdomain <- INLA::inla.nonconvex.hull(coords, -0.03, -0.05, resolution = c(50, 50))
-prmesh <- INLA::inla.mesh.2d(boundary = prdomain, max.edge = c(0.45, 1), cutoff = 0.5)
+prdomain <- fmesher::fm_nonconvex_hull_inla(coords, -0.03, -0.05, resolution = c(50, 50))
+prmesh <- fmesher::fm_mesh_2d(boundary = prdomain, max.edge = c(0.45, 1), cutoff = 0.5)
 
 
 rspde_model <- rspde.matern(mesh = prmesh, parameterization = "spde",
@@ -339,7 +339,7 @@ test_that("testing cgeneric_nonstat_fixed", {
   testthat::skip_on_cran()
 if (!requireNamespace("INLA", quietly=TRUE))
     testthat::skip(message = 'INLA package is not installed. (see www.r-inla.org/download-install)')
-  
+
   old_threads <- INLA::inla.getOption("num.threads")
   INLA::inla.setOption(num.threads = "1:1")
 
@@ -351,8 +351,8 @@ ind <- !is.na(Y)
 Y <- Y[ind]
 coords <- as.matrix(PRprec[ind, 1:2])
 
-prdomain <- INLA::inla.nonconvex.hull(coords, -0.03, -0.05, resolution = c(50, 50))
-prmesh <- INLA::inla.mesh.2d(boundary = prdomain, max.edge = c(0.45, 1), cutoff = 0.5)
+prdomain <- fmesher::fm_nonconvex_hull_inla(coords, -0.03, -0.05, resolution = c(50, 50))
+prmesh <- fmesher::fm_mesh_2d(boundary = prdomain, max.edge = c(0.45, 1), cutoff = 0.5)
 
 
 rspde_model <- rspde.matern(mesh = prmesh, nu = 0.7, parameterization = "spde",
@@ -396,7 +396,7 @@ test_that("testing cgeneric_nonstat_integer", {
   testthat::skip_on_cran()
 if (!requireNamespace("INLA", quietly=TRUE))
     testthat::skip(message = 'INLA package is not installed. (see www.r-inla.org/download-install)')
-  
+
   old_threads <- INLA::inla.getOption("num.threads")
   INLA::inla.setOption(num.threads = "1:1")
 
@@ -408,8 +408,8 @@ ind <- !is.na(Y)
 Y <- Y[ind]
 coords <- as.matrix(PRprec[ind, 1:2])
 
-prdomain <- INLA::inla.nonconvex.hull(coords, -0.03, -0.05, resolution = c(50, 50))
-prmesh <- INLA::inla.mesh.2d(boundary = prdomain, max.edge = c(0.45, 1), cutoff = 0.5)
+prdomain <- fmesher::fm_nonconvex_hull_inla(coords, -0.03, -0.05, resolution = c(50, 50))
+prmesh <- fmesher::fm_mesh_2d(boundary = prdomain, max.edge = c(0.45, 1), cutoff = 0.5)
 
 
 rspde_model <- rspde.matern(mesh = prmesh, parameterization = "spde", nu = 1,


### PR DESCRIPTION
As outlined in [https://inlabru-org.github.io/fmesher/articles/inla_conversion.html](https://inlabru-org.github.io/fmesher/articles/inla_conversion.html), package testing should set the `fmesher.evolution.warn=TRUE` and `fmesher.evolution.verbosity="stop"` INLA options to detect use of deprecated INLA mesh related methods. This patch adds that, and fixes the existing tests affected by it.