### PR TITLE
Propagate shared_lib parameter to rspde.matern() function calls

### DIFF
--- a/R/inla_rspde.R
+++ b/R/inla_rspde.R
@@ -3451,7 +3451,8 @@ rspde.metric_graph <- function(graph_obj,
       nu.prec.inc = nu.prec.inc,
       type.rational.approx = type.rational.approx,
       vec_param = param,
-      prior.theta.param = prior.theta.param
+      prior.theta.param = prior.theta.param,
+      shared_lib = shared_lib
     )
   } else {
     rspde_model <- rspde.matern(
@@ -3470,7 +3471,8 @@ rspde.metric_graph <- function(graph_obj,
       nu.prec.inc = nu.prec.inc,
       type.rational.approx = type.rational.approx,
       vec_param = param,
-      prior.theta.param = prior.theta.param
+      prior.theta.param = prior.theta.param,
+      shared_lib = shared_lib
     )
   }
 


### PR DESCRIPTION
The rspde.metric_graph() function has a shared_lib parameter but does not pass it on when it calls the rspde.matern() function which also takes the shared_lib parameter.

This patch adds the shared_lib parameter to the rspde.matern() function calls made in the body of the rspde.metric_graph() function.

This fixes the following error when using shared_lib="rSPDE" with the rspde.metric_graph() function:

Error in path.expand(path) : invalid 'path' argument
Calls: rspde.metric_graph ... do.call -> -> normalizePath -> path.expand
In addition: Warning message:
In normalizePath(paste0(dirname(inla.call.builtin()), "/external/", :
path[1]="/cluster/installations/eessi/default/2025.06/software/linux/x86_64/intel/skylake_avx512/software/R-INLA/25.06.22-foss-2025a/INLA/bin/linux/64bit/external/rSPDE/librSPDE.so": No such file or directory